### PR TITLE
doc: add blurb to N-API recommending the use of badges

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -105,6 +105,15 @@ opt-in to access those APIs:
 In this case the entire API surface, including any experimental APIs, will be
 available to the module code.
 
+### Badges
+The use of badges is recommended to indicate the minimum version of N-API required for the module. This helps to determine which Node.js major versions are supported. The following badges are available:
+
+![N--API-v1-green](https://img.shields.io/badge/N--API-v1-green.svg)
+![N--API-v2-green](https://img.shields.io/badge/N--API-v2-green.svg)
+![N--API-v3-green](https://img.shields.io/badge/N--API-v3-green.svg)
+![N--API-experimental-orange](https://img.shields.io/badge/N--API-experimental-orange.svg)
+
+
 ## N-API Version Matrix
 
 |       | 1       | 2        | 3        |


### PR DESCRIPTION
Added a blurb to the N-API documentation recommending the use of badges to specify
which minimum version of N-API the module uses.

Fixes: https://github.com/nodejs/node/issues/22796

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
